### PR TITLE
Update ChatHttpClient.java

### DIFF
--- a/src/main/oy/tol/chatclient/ChatHttpClient.java
+++ b/src/main/oy/tol/chatclient/ChatHttpClient.java
@@ -198,7 +198,7 @@ public class ChatHttpClient {
 			serverNotification = "";
 		} else {
 			BufferedReader in = new BufferedReader(
-					new InputStreamReader(connection.getErrorStream(), StandardCharsets.UTF_8));
+					new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
 			String inputLine;
 			while ((inputLine = in.readLine()) != null) {
 				serverNotification += " " + inputLine;


### PR DESCRIPTION
Patch will fix a NullPointerException which was caused by giving (null) ErrorStream as an argument to a InputStreamReader. NullPointerException was thrown if a valid and logged user tried to post a message but the server returned an error code.